### PR TITLE
User Settings Folder Change

### DIFF
--- a/Services/UserSettingsService.cs
+++ b/Services/UserSettingsService.cs
@@ -16,6 +16,11 @@ public class UserSettingsService
     private static readonly string userSettingsFilePath = Path.Combine(userSettingsFolderPath,
         USER_SETTINGS_FILE_NAME);
 
+    private static readonly JsonSerializerOptions jsonSerializerOptions = new(JsonSerializerOptions.Default)
+    {
+        WriteIndented = true
+    };
+
     private UserSettings userSettings = new();
 
     public string? DatabaseFilePath => userSettings.DatabaseFilePath;
@@ -36,7 +41,7 @@ public class UserSettingsService
     {
         Directory.CreateDirectory(userSettingsFolderPath);
         await using var createStream = File.Create(userSettingsFilePath);
-        await JsonSerializer.SerializeAsync(createStream, userSettings);
+        await JsonSerializer.SerializeAsync(createStream, userSettings, jsonSerializerOptions);
     }
 
     public async Task SetDatabaseFilePath(string? databaseFilePath)

--- a/Services/UserSettingsService.cs
+++ b/Services/UserSettingsService.cs
@@ -8,7 +8,7 @@ namespace CourseEquivalencyDesktop.Services;
 
 public class UserSettingsService
 {
-    private const string APP_DATA_FOLDER_NAME = "CourseEquivalencyDesktop";
+    private const string APP_DATA_FOLDER_NAME = "ExCourseEquivalency";
     private const string USER_SETTINGS_FILE_NAME = "Settings.json";
 
     private static readonly string userSettingsFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),


### PR DESCRIPTION
# Main Task
- Changing the folder name for the settings to ExCourseEquivalency to match the other consumer-facing names.
- Updating the settings file to be indented so that it is easier to manually read and update should anything go wrong and that be necessary.