### PR TITLE
Empty HyperlinkButton Fix

### DIFF
--- a/Views/Courses/CoursesPageView.axaml.cs
+++ b/Views/Courses/CoursesPageView.axaml.cs
@@ -3,7 +3,6 @@ using CourseEquivalencyDesktop.Models;
 using CourseEquivalencyDesktop.Services;
 using CourseEquivalencyDesktop.ViewModels.General;
 using CourseEquivalencyDesktop.Views.General;
-using CourseEquivalencyDesktop.Views.Students;
 
 namespace CourseEquivalencyDesktop.Views.Courses;
 
@@ -26,7 +25,7 @@ public partial class CoursesPageView : BasePageViewCodeBehind<Course>
     {
         var viewModel =
             Ioc.Default.GetRequiredService<ServiceCollectionExtensions.CreateOrEditCourseViewModelFactory>()(item);
-        var window = new CreateOrEditStudentWindow
+        var window = new CreateOrEditCourseWindow
         {
             DataContext = viewModel
         };

--- a/Views/CustomControls/ExtendedHyperlinkButton.axaml.cs
+++ b/Views/CustomControls/ExtendedHyperlinkButton.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Threading;
 
 namespace CourseEquivalencyDesktop.Views.CustomControls;
@@ -29,6 +30,11 @@ public class ExtendedHyperlinkButton : HyperlinkButton
     {
         base.OnPropertyChanged(change);
 
+        if (change.Property == ContentProperty)
+        {
+            SetVisibility();
+        }
+
         if (!IsEmail)
         {
             return;
@@ -50,10 +56,15 @@ public class ExtendedHyperlinkButton : HyperlinkButton
         }
     }
 
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+
+        SetVisibility();
+    }
+
     protected override void OnClick()
     {
-        base.OnClick();
-
         var uri = IsEmail ? emailUri : NavigateUri;
         if (uri is null)
         {
@@ -70,6 +81,13 @@ public class ExtendedHyperlinkButton : HyperlinkButton
                 SetCurrentValue(IsVisitedProperty, true);
             }
         }
+    }
+    #endregion
+
+    #region Helpers
+    private void SetVisibility()
+    {
+        IsVisible = Content is not null;
     }
     #endregion
 }


### PR DESCRIPTION
# Main Task
Fixing a bug where empty hyperlink buttons would be generated for url/email columns without values.

## Additional Tasks
- Fixing a bug where links would open twice.
- Fixing a bug where the wrong edit window would open for courses.

## Closed Issues
- Closes #40 (Fixed)