### PR TITLE
Settings Department Not Initially Set

### DIFF
--- a/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/ViewModels/Settings/SettingsPageViewModel.cs
@@ -64,6 +64,7 @@ public partial class SettingsPageViewModel : BaseViewModel
         this.genericDialogService = genericDialogService;
 
         UserFullName = userSettingsService.UserFullName;
+        UserDepartment = userSettingsService.UserDepartment;
         UserEmail = userSettingsService.UserEmail;
         SearchDelay = userSettingsService.SearchDebounceSeconds;
         DataGridPageSize = userSettingsService.DataGridPageSize;


### PR DESCRIPTION
# Main Task
Fixing a bug where the department would not have its current value set when navigating to the settings page.

## Closed Issues
- Closes #55 (Complete)

