### PR TITLE
Course search box not populating bug

### DIFF
--- a/ViewModels/StudyPlans/StudyPlansPageViewModel.cs
+++ b/ViewModels/StudyPlans/StudyPlansPageViewModel.cs
@@ -36,18 +36,10 @@ public class StudyPlansPageViewModel : BasePageViewModel<StudyPlan>
     {
         Items.Clear();
 
-        // TODO: Get teh item in the edit window instead to not pull everything for everything at once
-        // Using the Include to eagerly load study plans and related information so they are ready on first page view
+        // Using the Include to eagerly load the student and university so they are ready on first page view
         Items.AddRange(DatabaseService.StudyPlans
             .Include(studyPlan => studyPlan.Student)
-            .ThenInclude(student => student.University)
-            .ThenInclude(university => university.Courses)
-            .ThenInclude(courses => courses.Equivalencies)
-            .Include(studyPlan => studyPlan.DestinationUniversity)
-            .ThenInclude(university => university.Courses)
-            .ThenInclude(courses => courses.Equivalencies)
-            .Include(studyPlan => studyPlan.HomeUniversityCourses)
-            .Include(studyPlan => studyPlan.DestinationUniversityCourses));
+            .Include(studyPlan => studyPlan.DestinationUniversity));
     }
 
     protected override Task<HashSet<StudyPlan>> Remove(StudyPlan item)

--- a/Views/General/MainWindow.axaml
+++ b/Views/General/MainWindow.axaml
@@ -9,7 +9,8 @@
         x:Class="CourseEquivalencyDesktop.Views.General.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="ExCourseEquivalency"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        WindowState="Maximized">
 
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,


### PR DESCRIPTION
# Main Task
Fixing a bug where the course search box on a study plan would not be populated. The root cause was that the list of courses would be taken from the study plan and they would only be loaded in the list, not the edit. This meant that on a fresh creation, the values would not yet be loaded and could not be displayed. This is likely the only place where it matters, but I should consider going through all of the pages and seeing if they should fresh load any data in the edit window and then async them as well to not block the UI thread.

## Additional Tasks
- Maximized the main window by default to prevent that having to be done by my father each time.

## Closed Issues
- Closes #64 (Fixed)

